### PR TITLE
This is how Oracle 8.0 support looks like

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ pmysql: pmysql.o threadpool.o
 
 clean:
 	rm -f pmysql *.o
+
+format:
+	clang-format -i *.[ch]

--- a/mysql_async.h
+++ b/mysql_async.h
@@ -1,0 +1,23 @@
+#include <mysql.h>
+
+enum net_async_block_state {
+  NET_NONBLOCKING_CONNECT = 0,
+  NET_NONBLOCKING_READ,
+  NET_NONBLOCKING_WRITE
+};
+
+typedef struct NET_ASYNC {
+  unsigned char* cur_pos;
+  enum net_async_block_state async_blocking_state;
+} NET_ASYNC;
+
+typedef struct NET_EXTENSION {
+  NET_ASYNC* net_async_context;
+  mysql_compress_context compress_ctx;
+} NET_EXTENSION;
+
+#define NET_EXTENSION_PTR(N) \
+  ((NET_EXTENSION*)((N)->extension ? (N)->extension : NULL))
+
+#define NET_ASYNC_DATA(M) \
+  ((NET_EXTENSION_PTR(M)) ? (NET_EXTENSION_PTR(M)->net_async_context) : NULL)


### PR DESCRIPTION
This is how Oracle 8.0 support looks like. 
Still seems to be broken w…ith 8.0.20, as there were many bugs in the client:

* https://bugs.mysql.com/bug.php?id=99112
* https://bugs.mysql.com/bug.php?id=99073
* https://bugs.mysql.com/bug.php?id=98980
* https://bugs.mysql.com/bug.php?id=98947
* https://bugs.mysql.com/bug.php?id=98574

We also are hitting https://bugs.mysql.com/bug.php?id=99805 - and have to work around that manually by accessing private data:
* mysql->(NET_ASYNC *)net->async_blocking_state
* mysql->net.(Vio *)vio->mysql_socket.fd

Still lacking feature: SSL context pooling/takeover.

It is not clear if this handles all the race conditions correctly yet, as it is definitely broken with stock 8.0.20.